### PR TITLE
demo.py --load parameter is now required as voc0712 can't be loaded

### DIFF
--- a/demo.py
+++ b/demo.py
@@ -11,18 +11,31 @@ chainer.config.train = False
 parser = argparse.ArgumentParser()
 parser.add_argument('image', help='path for input image')
 parser.add_argument('result', help='path for output image')
+"""
 parser.add_argument('--load', help='if not specified, use default model \
-                                                trained on voc07+12 trainval')
+                                                trained on voc07+12 trainval') #voc doesn't load anymore                                                
+parser.add_argument('--load', help='if not specified, the default is watercolor_dt_ssd300 \
+                                                trained on voc07+12 trainval is not available online anymore in the address checked by chainercv') #use this or other default
+"""                                              
+parser.add_argument('--load', help='required, e.g. watercolor_dt_ssd300 \
+                                                the original default, trained on voc07+12 trainval is not available online anymore in the address checked by chainercv') #use this or other default
+                                        
+                                                
+
 parser.add_argument('--gpu', type=int, default=-1)
 parser.add_argument('--score_thresh', type=float, default=0.25)
 args = parser.parse_args()
 
-model = SSD300(
-    n_fg_class=len(voc_bbox_label_names), pretrained_model='voc0712')
+model = SSD300(    
+    n_fg_class=len(voc_bbox_label_names, pretrained_model=args.load) #'voc0712' is not available anymore at https://chainercv-models.preferred.jp/ssd300_voc0712_converted_2017_06_06.npz)
+    #n_fg_class=len(voc_bbox_label_names, pretrained_model='watercolor_dt_ssd300') #'voc0712' is not available anymore at https://chainercv-models.preferred.jp/ssd300_voc0712_converted_2017_06_06.npz
 model.score_thresh = args.score_thresh
 
+"""
+# Now it's a required parameter and loaded on creation of SSD300:
 if args.load:
     chainer.serializers.load_npz(args.load, model)
+"""
 
 if args.gpu >= 0:
     chainer.cuda.get_device_from_id(args.gpu).use()


### PR DESCRIPTION
--load parameter is now required because the current default voc from chainer can't be loaded and it's in the archived project:  https://github.com/chainer/chainercv/blob/master/chainercv/links/model/ssd/ssd_vgg16.py

_models = {
        'voc0712': {
            'param': {'n_fg_class': 20},
            'url': 'https://chainercv-models.preferred.jp/'
            'ssd300_voc0712_converted_2017_06_06.npz',
            'cv2': True
        },
        'imagenet': {
            'url': 'https://chainercv-models.preferred.jp/'
            'ssd_vgg16_imagenet_converted_2017_06_09.npz',
            'cv2': True
        },
    }